### PR TITLE
remove code reference overload for extern

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}},
 
 {{$NEXT}}
+  - Remove code reference overload for Wasm::Wasmtime::Extern (gh#18)
 
 0.02      2020-04-11 08:36:52 -0600
   - Added -exporter option to Wasm module (gh#14)

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for {{$dist->name}}},
 
 {{$NEXT}}
   - Remove code reference overload for Wasm::Wasmtime::Extern (gh#18)
+  - Added kind and kind_num methods to Wasm::Wasmtime::Extern (gh#18)
+  - Added as_extern methods to Wasm::Wasmtime::Func and
+    Wasm::Wasmtime::Memory (gh#18)
 
 0.02      2020-04-11 08:36:52 -0600
   - Added -exporter option to Wasm module (gh#14)

--- a/author.yml
+++ b/author.yml
@@ -28,3 +28,4 @@ pod_coverage:
   # for either Class or method.
   private:
     - Wasm::Wasmtime::ExternType#new
+    - Wasm::Wasmtime::Extern#new

--- a/examples/gcd.pl
+++ b/examples/gcd.pl
@@ -5,6 +5,6 @@ use Wasm::Wasmtime;
 
 my $module = Wasm::Wasmtime::Module->new( file => path(__FILE__)->parent->child('gcd.wat') );
 my $instance = Wasm::Wasmtime::Instance->new($module);
-my $gcd = $instance->get_export('gcd');
+my $gcd = $instance->get_export('gcd')->as_func;
 
 print "gcd(6,27) = @{[ $gcd->(6,27) ]}\n";

--- a/examples/hello.pl
+++ b/examples/hello.pl
@@ -25,4 +25,4 @@ my $hello = Wasm::Wasmtime::Func->new(
 
 ## And with all that we can instantiate our module and call the export!
 my $instance = Wasm::Wasmtime::Instance->new($module, [$hello]);
-$instance->get_export("run")->();
+$instance->get_export("run")->as_func->();

--- a/examples/synopsis/exporttype.pl
+++ b/examples/synopsis/exporttype.pl
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Wasm::Wasmtime;
+
+my $module = Wasm::Wasmtime::Module->new(wat => q{
+  (module
+    (func (export "foo") (param i32 i32) (result i32)
+      local.get 0
+      local.get 1
+      i32.add)
+    (memory (export "bar") 2 3)
+  )
+});
+
+my($foo, $bar) = $module->exports;
+
+print $foo->name, "\n";        # foo
+print $foo->type->kind, "\n";  # func
+print $bar->name, "\n";        # bar
+print $bar->type->kind, "\n";  # memory

--- a/examples/synopsis/extern.pl
+++ b/examples/synopsis/extern.pl
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Wasm::Wasmtime;
+
+my $instance = Wasm::Wasmtime::Instance->new(
+  Wasm::Wasmtime::Module->new(wat => q{
+    (module
+      (func (export "foo") (param i32 i32) (result i32)
+        local.get 0
+        local.get 1
+        i32.add)
+      (memory (export "bar") 2 3)
+    )
+  }),
+);
+
+my $externtype_foo = $instance->get_export('foo');
+print $externtype_foo->kind, "\n";  # func
+
+my $externtype_bar = $instance->get_export('bar');
+print $externtype_bar->kind, "\n";  # memory

--- a/examples/synopsis/wasmtime.pl
+++ b/examples/synopsis/wasmtime.pl
@@ -57,16 +57,16 @@ my $hello = Wasm::Wasmtime::Func->new(
 my $instance = Wasm::Wasmtime::Instance->new( $module, [$hello] );
 
 # call a WebAssembly function that calls back into Perl space
-$instance->get_export('call_hello')->();
+$instance->get_export('call_hello')->as_func;
 
 # call plain WebAssembly function
-my $gcd = $instance->get_export('gcd');
+my $gcd = $instance->get_export('gcd')->as_func;
 print $gcd->(6,27), "\n";      # 3
 
 # write to memory from Perl and read it from WebAssembly
 my $memory = $instance->get_export('memory')->as_memory;
 poke($memory->data + 10, 42);  # set offset 10 to 42
-my $load = $instance->get_export('load');
+my $load = $instance->get_export('load')->as_func;
 print $load->(10), "\n";       # 42
 poke($memory->data + 10, 52);  # set offset 10 to 52
 print $load->(10), "\n";       # 52

--- a/lib/Wasm/Wasmtime/ExportType.pm
+++ b/lib/Wasm/Wasmtime/ExportType.pm
@@ -8,29 +8,79 @@ use Wasm::Wasmtime::ExternType;
 # ABSTRACT: Wasmtime export type class
 # VERSION
 
-$ffi_prefix = 'wasm_exporttype_';
-$ffi->type('opaque' => 'wasm_exporttype_t');
+=head1 SYNOPSIS
 
-=head1 CONSTRUCTORS
+# EXAMPLE: examples/synopsis/exporttype.pl
 
-=head2 new
+=head1 DESCRIPTION
+
+This class represents an export from a module.  It is essentially a name
+and an L<Wasm::Wasmtime::ExternType>.  The latter gives you the function
+signature and other configuration details for exportable objects.
 
 =cut
 
-sub new
-{
-  my($class, $ptr, $owner) = @_;
-  bless {
-    ptr   => $ptr,
-    owner => $owner,
-  }, $class;
-}
+$ffi_prefix = 'wasm_exporttype_';
+$ffi->type('opaque' => 'wasm_exporttype_t');
+
+=head1 CONSTRUCTOR
+
+=head2 new
+
+ my $exporttype = Wasm::Wasmtime::ExportType->new(
+   $name,         # string
+   $externtype,   # Wasm::Wasmtime::ExternType
+ );
+
+Creates a new export type object.
+
+=cut
+
+$ffi->attach( new => ['wasm_byte_vec_t*', 'wasm_externtype_t'] => 'wasm_exporttype_t' => sub {
+  my $xsub = shift;
+  my $class = shift;
+  my($ptr, $owner);
+  if(defined $_[1] && ref($_[1]) eq 'Wasm::Wasmtime::ExternType')
+  {
+    # not sure this is actually useful?
+    # doesn't seem to bee a way to new an wasm_externtype_t
+    my $name = Wasm::Wasmtime::ByteVec->new(shift);
+    my $externtype = shift;
+    my $ptr = $xsub->($name, $externtype->{ptr});
+  }
+  else
+  {
+    ($ptr,$owner) = @_;
+    bless {
+      ptr   => $ptr,
+      owner => $owner,
+    }, $class;
+  }
+});
+
+=head1 METHODS
+
+=head2 name
+
+ my $name = $exporttype->name;
+
+Returns the name of the export.
+
+=cut
 
 $ffi->attach( name => ['wasm_exporttype_t'] => 'wasm_byte_vec_t*' => sub {
   my($xsub, $self) = @_;
   my $name = $xsub->($self->{ptr});
   $name->get;
 });
+
+=head2 type
+
+ my $externtype = $exporttype->type;
+
+Returns the L<Wasm::Wasmtime::ExternType> for the export.
+
+=cut
 
 $ffi->attach( type => ['wasm_exporttype_t'] => 'wasm_externtype_t' => sub {
   my($xsub, $self) = @_;

--- a/lib/Wasm/Wasmtime/Extern.pm
+++ b/lib/Wasm/Wasmtime/Extern.pm
@@ -6,10 +6,6 @@ use Wasm::Wasmtime::FFI;
 use Wasm::Wasmtime::Func;
 use Wasm::Wasmtime::Memory;
 use Wasm::Wasmtime::ExternType;
-use overload
-  '&{}' => sub { my $self = shift; sub { $self->call(@_) } },
-  bool => sub { 1 },
-  fallback => 1;
 
 # ABSTRACT: Wasmtime extern class
 # VERSION
@@ -30,18 +26,6 @@ sub new
     ptr   => $ptr,
     owner => $owner,
   }, $class;
-}
-
-=head1 METHODS
-
-=head2 call
-
-=cut
-
-sub call
-{
-  my $self = shift;
-  $self->as_func->call(@_);
 }
 
 $ffi->attach( type => ['wasm_extern_t'] => 'wasm_externtype_t' => sub {

--- a/lib/Wasm/Wasmtime/Extern.pm
+++ b/lib/Wasm/Wasmtime/Extern.pm
@@ -10,14 +10,18 @@ use Wasm::Wasmtime::ExternType;
 # ABSTRACT: Wasmtime extern class
 # VERSION
 
-$ffi_prefix = 'wasm_extern_';
-$ffi->type('opaque' => 'wasm_extern_t');
+=head1 SYNOPSIS
 
-=head1 CONSTRUCTORS
+# EXAMPLE: examples/synopsis/extern.pl
 
-=head2 new
+=head1 DESCRIPTION
+
+This class represents an object exported from L<Wasm::Wasmtime::Instance>.
 
 =cut
+
+$ffi_prefix = 'wasm_extern_';
+$ffi->type('opaque' => 'wasm_extern_t');
 
 sub new
 {
@@ -28,10 +32,74 @@ sub new
   }, $class;
 }
 
+=head1 METHODS
+
+=head2 type
+
+ my $externtype = $extern->type;
+
+Returns the L<Wasm::Wasmtime::ExternType> for this extern.
+
+=cut
+
 $ffi->attach( type => ['wasm_extern_t'] => 'wasm_externtype_t' => sub {
   my($xsub, $self) = @_;
   Wasm::Wasmtime::ExternType->new($xsub->($self->{ptr}), undef);
 });
+
+my %kind = (
+  0 => 'func',
+  1 => 'global',
+  2 => 'table',
+  3 => 'memory',
+);
+
+=head2 kind
+
+ my $kind = $extern->kind;
+
+Returns the kind of extern.  Should be one of:
+
+=over 4
+
+=item C<func>
+
+=item C<global>
+
+=item C<table>
+
+=item C<memory>
+
+=back
+
+=cut
+
+$ffi->attach( kind => ['wasm_extern_t'] => 'uint8' => sub {
+  my($xsub, $self) = @_;
+  $kind{$xsub->($self->{ptr})};
+});
+
+=head2 kind_num
+
+ my $kind = $extern->kind_num;
+
+Returns the kind of extern as the internal integer used by Wasmtime.
+
+=cut
+
+$ffi->attach( [ kind => 'kind_num' ] => ['wasm_extern_t'] => 'uint8' => sub {
+  my($xsub, $self) = @_;
+  $xsub->($self->{ptr});
+});
+
+=head2 as_func
+
+ my $func = $extern->as_func;
+
+If the extern is a C<func>, returns its L<Wasm::Wasmtime::Func>.
+Otherwise returns C<undef>.
+
+=cut
 
 $ffi->attach( as_func => ['wasm_extern_t'] => 'wasm_func_t' => sub {
   my($xsub, $self) = @_;
@@ -39,6 +107,15 @@ $ffi->attach( as_func => ['wasm_extern_t'] => 'wasm_func_t' => sub {
   return undef unless $ptr;
   Wasm::Wasmtime::Func->new($ptr, $self->{owner} || $self);
 });
+
+=head2 as_memory
+
+ my $memory = $extern->as_memory;
+
+If the extern is a C<memory>, returns its L<Wasm::Wasmtime::Memory>.
+Otherwise returns C<undef>.
+
+=cut
 
 $ffi->attach( as_memory => ['wasm_extern_t'] => 'wasm_memory_t' => sub {
   my($xsub, $self) = @_;

--- a/lib/Wasm/Wasmtime/Func.pm
+++ b/lib/Wasm/Wasmtime/Func.pm
@@ -237,6 +237,22 @@ $ffi->attach( result_arity => ['wasm_func_t'] => 'size_t' => sub {
   $xsub->($self->{ptr});
 });
 
+=head2 as_extern
+
+ my $extern = $func->as_extern;
+
+Returns the L<Wasm::Wasmtime::Extern> for this function.
+
+=cut
+
+# actually returns a wasm_extern_t, but recursion
+$ffi->attach( as_extern => ['wasm_func_t'] => 'opaque' => sub {
+  my($xsub, $self) = @_;
+  require Wasm::Wasmtime::Extern;
+  my $ptr = $xsub->($self->{ptr});
+  Wasm::Wasmtime::Extern->new($ptr, $self->{owner} || $self);
+});
+
 _generate_destroy();
 
 1;

--- a/lib/Wasm/Wasmtime/Memory.pm
+++ b/lib/Wasm/Wasmtime/Memory.pm
@@ -127,6 +127,22 @@ $ffi->attach( grow => ['wasm_memory_t', 'uint32'] => 'bool' => sub {
   $xsub->($self->{ptr}, $delta);
 });
 
+=head2 as_extern
+
+ my $extern = $memory->as_extern;
+
+Returns the L<Wasm::Wasmtime::Extern> for this memory object.
+
+=cut
+
+# actually returns a wasm_extern_t, but recursion
+$ffi->attach( as_extern => ['wasm_memory_t'] => 'opaque' => sub {
+  my($xsub, $self) = @_;
+  require Wasm::Wasmtime::Extern;
+  my $ptr = $xsub->($self->{ptr});
+  Wasm::Wasmtime::Extern->new($ptr, $self->{owner} || $self);
+});
+
 $ffi->attach( [ delete => "DESTROY" ] => ['wasm_memory_t'] => sub {
   my($xsub, $self) = @_;
   if(defined $self->{ptr} && !defined $self->{owner})

--- a/t/wasm_wasmtime_exporttype.t
+++ b/t/wasm_wasmtime_exporttype.t
@@ -1,8 +1,38 @@
 use Test2::V0 -no_srand => 1;
+use lib 't/lib';
+use Test2::Tools::Wasm;
 use Wasm::Wasmtime::ExportType;
 
-diag 'todo';
-
-ok 1;
+is(
+  wasm_module_ok(q{
+    (module
+      (func (export "foo") (param i32 i32) (result i32)
+        local.get 0
+        local.get 1
+        i32.add)
+      (memory (export "bar") 2 3)
+    )
+  }),
+  object {
+    call_list exports => array {
+      item object {
+        call [ isa => 'Wasm::Wasmtime::ExportType' ] => T();
+        call name => 'foo';
+        call type => object {
+          call [ isa => 'Wasm::Wasmtime::ExternType' ] => T();
+        };
+      };
+      item object {
+        call [ isa => 'Wasm::Wasmtime::ExportType' ] => T();
+        call name => 'bar';
+        call type => object {
+          call [ isa => 'Wasm::Wasmtime::ExternType' ] => T();
+        };
+      };
+      end;
+    };
+  },
+  'export types okay',
+);
 
 done_testing;

--- a/t/wasm_wasmtime_extern.t
+++ b/t/wasm_wasmtime_extern.t
@@ -1,8 +1,45 @@
 use Test2::V0 -no_srand => 1;
+use lib 't/lib';
+use Test2::Tools::Wasm;
 use Wasm::Wasmtime::Extern;
 
-diag 'todo';
-
-ok 1;
+is(
+  wasm_instance_ok([], q{
+    (module
+      (func (export "foo") (param i32 i32) (result i32)
+        local.get 0
+        local.get 1
+        i32.add)
+      (memory (export "bar") 2 3)
+    )
+  }),
+  object {
+    call [ get_export => 'foo' ] => object{
+      call [ isa => 'Wasm::Wasmtime::Extern' ] => T();
+      call type => object {
+        call [ isa => 'Wasm::Wasmtime::ExternType' ] => T();
+      };
+      call kind      => 'func';
+      call kind_num  => match qr/^[0-9]+$/;
+      call as_func   => object {
+        call [ isa => 'Wasm::Wasmtime::Func' ] => T();
+      };
+      call as_memory => U();
+    };
+    call [ get_export => 'bar' ] => object{
+      call [ isa => 'Wasm::Wasmtime::Extern' ] => T();
+      call type => object {
+        call [ isa => 'Wasm::Wasmtime::ExternType' ] => T();
+      };
+      call kind      => 'memory';
+      call kind_num  => match qr/^[0-9]+$/;
+      call as_func   => U();
+      call as_memory => object {
+        call [ isa => 'Wasm::Wasmtime::Memory' ] => T();
+      };
+    };
+  },
+  'exter objects',
+);
 
 done_testing;

--- a/t/wasm_wasmtime_func.t
+++ b/t/wasm_wasmtime_func.t
@@ -19,6 +19,14 @@ is(
   object {
     call [ call => 1, 2 ] => 3;
     call [ call => 3, 4 ] => 7;
+    call type => object {
+      call [ isa => 'Wasm::Wasmtime::FuncType' ] => T();
+    };
+    call param_arity => 2;
+    call result_arity => 1;
+    call as_extern => object {
+      call [ isa => 'Wasm::Wasmtime::Extern' ] => T();
+    };
   },
   'call add',
 );

--- a/t/wasm_wasmtime_instance.t
+++ b/t/wasm_wasmtime_instance.t
@@ -117,7 +117,7 @@ wasm_instance_ok [], '(module)';
   );
 
   my $instance = Wasm::Wasmtime::Instance->new($module, [$hello]);
-  $instance->get_export("run")->();
+  $instance->get_export("run")->as_func->();
 
   is $it_works, T(), 'callback called';
 }

--- a/t/wasm_wasmtime_memory.t
+++ b/t/wasm_wasmtime_memory.t
@@ -24,6 +24,9 @@ is(
         call size => 2;
         call [ grow => 3] => T();
         call size => 5;
+        call as_extern => object {
+          call [ isa => 'Wasm::Wasmtime::Extern' ] => T();
+        };
       };
     };
   },


### PR DESCRIPTION
This interface was borrowed from the Python implementation, but it feels a little impure.

This PR also completes documentation of the implemented classes, and adds a few missing methods.