### PR TITLE
Test2 plugin to workaround wasm memory challenges

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}},
 
 {{$NEXT}}
+  - Add Test2::Plugin::Wasm (gh#36)
 
   [Warning: numerous breaking changes]
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,22 @@ As mentioned before as of this writing this dist is a work in progress.  I won't
 stuff if I don't have to, but practicality may demand it in some situations.
 
 This interface is implemented using the bundled [Wasm::Wasmtime](https://metacpan.org/pod/Wasm::Wasmtime) family of modules, which depends
-on the Wasmtime project.  Because of the way Wasmtime handles out-of-bounds memory errors, large
-`PROT_NONE` pages are allocated at startup.  While these pages do not consume any actual resources
-(as used by Wasmtime), they can cause out-of-memory errors on Linux systems with virtual memory
-limits (`ulimit -v`).  Similar techniques are common in modern programming languages, and this
-seems to be more a limitation of the Linux kernel.
+on the Wasmtime project.
+
+The default way of handling out-of-bounds memory errors is to allocate large `PROT_NONE` pages at
+startup.  While these pages do not consume many resources in practice (at least in the way that they
+are used by Wasmtime), they can cause out-of-memory errors on Linux systems with virtual memory
+limits (`ulimi -v` in the `bash` shell).  Similar techniques are common in other modern programming
+languages, and this is more a limitation of the Linux kernel than anything else.  Setting the limits
+on the virtual memory address size probably doesn't do what you think it is doing and you are probably
+better off finding a way to place limits on process memory.
+
+However, as a workaround for environments that choose to set a virtual memory address size limit anyway,
+Wasmtime provides configurations to not allocate the large `PROT_NONE` pages at some performance
+cost.  The testing plugin [Test2::Plugin::Wasm](https://metacpan.org/pod/Test2::Plugin::Wasm) tries to detect environments that have the virtual
+memory address size limits and sets this configuration for you.  For production you can set the
+environment variable `PERL_WASM_WASMTIME_MEMORY` to tune the appropriate memory settings exactly
+as you want to (see the environment section of [Wasm::Wasmtime](https://metacpan.org/pod/Wasm::Wasmtime).
 
 # SEE ALSO
 

--- a/author.yml
+++ b/author.yml
@@ -30,3 +30,4 @@ pod_coverage:
     - Wasm::Wasmtime::ExternType#new
     - Wasm::Wasmtime::Extern#new
     - Wasm::Wasmtime::Table#new
+    - Test2::Plugin::Wasm

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ copyright_year   = 2020
 version          = 0.06
 
 [@Author::Plicease]
-:version       = 2.44
+:version       = 2.47
 travis_status  = 1
 release_tests  = 1
 installer      = Author::Plicease::MakeMaker

--- a/lib/Test2/Plugin/Wasm.pm
+++ b/lib/Test2/Plugin/Wasm.pm
@@ -102,9 +102,9 @@ sub import
         new => sub {
           my $orig = shift;
           my $self = shift->$orig(@_);
-          $self->static_memory_maximum_size($vm_limit/4);
-          $self->static_memory_guard_size(1024);
-          $self->dynamic_memory_guard_size(1024);
+          $self->static_memory_maximum_size(0);
+          $self->static_memory_guard_size(0);
+          $self->dynamic_memory_guard_size(0);
           $self;
         },
       ],

--- a/lib/Test2/Plugin/Wasm.pm
+++ b/lib/Test2/Plugin/Wasm.pm
@@ -18,7 +18,7 @@ use FFI::C::Util qw( c_to_perl );
 
 This L<Test2> plugin is for testing L<Wasm> extensions.  Right now, it sets C<wasmtime> resource
 limits to work on systems with a low virtual memory address limit.  It may do other thing that
-make sense for all L<Wasm> extensions in the future.
+make sense for all L<Wasm> extensions running in a testing context in the future.
 
 =head1 SEE ALSO
 

--- a/lib/Test2/Plugin/Wasm.pm
+++ b/lib/Test2/Plugin/Wasm.pm
@@ -5,6 +5,31 @@ use warnings;
 use Test2::API qw( context );
 use Test2::Mock;
 
+# ABSTRACT: Test2 plugin for Wasm extensions
+# VERSION
+
+=head1 SYNOPSIS
+
+ use Test2::Plugin::Wasm;
+
+=head1 DESCRIPTION
+
+This L<Test2> plugin is for testing L<Wasm> extensions.  Right now, it sets C<wasmtime> resource
+limits to work on systems with a low virtual memory address limit.  It may do other thing that
+make sense for all L<Wasm> extensions in the future.
+
+=head1 SEE ALSO
+
+=over 4
+
+=item L<Wasm>
+
+Write Perl extensions using Web Assembly.
+
+=back
+
+=cut
+
 sub get_virtual_memory_limit
 {
   my $ctx = context();

--- a/lib/Test2/Plugin/Wasm.pm
+++ b/lib/Test2/Plugin/Wasm.pm
@@ -1,0 +1,91 @@
+package Test2::Plugin::Wasm;
+
+use strict;
+use warnings;
+use Test2::API qw( context );
+use Test2::Mock;
+
+sub get_virtual_memory_limit
+{
+  my $ctx = context();
+  if($^O eq 'linux')
+  {
+    require FFI::Platypus;
+    require FFI::C::StructDef;
+    my $ffi = FFI::Platypus->new( api => 1, lib => [undef] );
+    my $rlimit;
+    if($ffi->find_symbol('getrlimit64'))
+    {
+      $ctx->note("linux : found getrlimit64") if $ENV{TEST2_PLUGIN_WASM_DEBUG};
+      $rlimit = FFI::C::StructDef->new(
+        $ffi,
+        name => 'rlimit',
+        members => [
+          rlim_cur => 'uint64',
+          rlim_max => 'uint64',
+        ],
+      )->create;
+      my $ret = $ffi->function( getrlimit64 => [ 'int', 'rlimit' ] => 'int' )->call(9,$rlimit);
+      if($ret == -1)
+      {
+        $ctx->note("getrlimit64 failed: $!") if $ENV{TEST2_PLUGIN_WASM_DEBUG};
+        undef $rlimit;
+      }
+    }
+    elsif($ffi->find_symbol('getrlimit'))
+    {
+      $ctx->note("linux : found getrlimit") if $ENV{TEST2_PLUGIN_WASM_DEBUG};
+      $rlimit = FFI::C::StructDef->new(
+        $ffi,
+        name => 'rlimit',
+        members => [
+          rlim_cur => 'uint32',
+          rlim_max => 'uint32',
+        ],
+      )->create;
+      my $ret = $ffi->function( getrlimit => [ 'int', 'rlimit' ] => 'int' )->call(9,$rlimit);
+      if($ret == -1)
+      {
+        $ctx->note("getrlimit failed: $!") if $ENV{TEST2_PLUGIN_WASM_DEBUG};
+        undef $rlimit;
+      }
+    }
+    if(defined $rlimit)
+    {
+      my $max = $rlimit->rlim_max;
+      $ctx->note("rlimit->rlim_max = $max") if $ENV{TEST2_PLUGIN_WASM_DEBUG};
+      $ctx->release;
+      return $max;
+    }
+  }
+  $ctx->release;
+  return undef;
+}
+
+our $config_mock;
+
+sub import
+{
+  my $ctx = context();
+  my $vm_limit = get_virtual_memory_limit();
+  if(defined $vm_limit)
+  {
+    require Wasm::Wasmtime::Config;
+    $config_mock = Test2::Mock->new(
+      class => 'Wasm::Wasmtime::Config',
+      around => [
+        new => sub {
+          my $orig = shift;
+          my $self = shift->$orig(@_);
+          $self->static_memory_maximum_size($vm_limit/4);
+          $self->static_memory_guard_size(1024);
+          $self->dynamic_memory_guard_size(1024);
+          $self;
+        },
+      ],
+    );
+  }
+  $ctx->release;
+}
+
+1;

--- a/lib/Wasm.pm
+++ b/lib/Wasm.pm
@@ -106,6 +106,8 @@ Load WebAssembly modules as though they were Perl modules.
 
 =cut
 
+my $store;
+
 sub import
 {
   my $class = shift;
@@ -195,10 +197,12 @@ sub import
   @module = (wat => '(module)') unless @module;
 
   require Wasm::Wasmtime;
-  my $config = Wasm::Wasmtime::Config->new;
-  $config->wasm_multi_value(1);
-  my $engine = Wasm::Wasmtime::Engine->new($config);
-  my $store = Wasm::Wasmtime::Store->new($engine);
+  $store ||= do {
+    my $config = Wasm::Wasmtime::Config->new;
+    $config->wasm_multi_value(1);
+    my $engine = Wasm::Wasmtime::Engine->new($config);
+    Wasm::Wasmtime::Store->new($engine);
+  };
   my $module = Wasm::Wasmtime::Module->new($store, @module);
   my $instance = Wasm::Wasmtime::Instance->new($module, \@imports);
 

--- a/lib/Wasm.pm
+++ b/lib/Wasm.pm
@@ -84,11 +84,22 @@ As mentioned before as of this writing this dist is a work in progress.  I won't
 stuff if I don't have to, but practicality may demand it in some situations.
 
 This interface is implemented using the bundled L<Wasm::Wasmtime> family of modules, which depends
-on the Wasmtime project.  Because of the way Wasmtime handles out-of-bounds memory errors, large
-C<PROT_NONE> pages are allocated at startup.  While these pages do not consume any actual resources
-(as used by Wasmtime), they can cause out-of-memory errors on Linux systems with virtual memory
-limits (C<ulimit -v>).  Similar techniques are common in modern programming languages, and this
-seems to be more a limitation of the Linux kernel.
+on the Wasmtime project.
+
+The default way of handling out-of-bounds memory errors is to allocate large C<PROT_NONE> pages at
+startup.  While these pages do not consume many resources in practice (at least in the way that they
+are used by Wasmtime), they can cause out-of-memory errors on Linux systems with virtual memory
+limits (C<ulimi -v> in the C<bash> shell).  Similar techniques are common in other modern programming
+languages, and this is more a limitation of the Linux kernel than anything else.  Setting the limits
+on the virtual memory address size probably doesn't do what you think it is doing and you are probably
+better off finding a way to place limits on process memory.
+
+However, as a workaround for environments that choose to set a virtual memory address size limit anyway,
+Wasmtime provides configurations to not allocate the large C<PROT_NONE> pages at some performance
+cost.  The testing plugin L<Test2::Plugin::Wasm> tries to detect environments that have the virtual
+memory address size limits and sets this configuration for you.  For production you can set the
+environment variable C<PERL_WASM_WASMTIME_MEMORY> to tune the appropriate memory settings exactly
+as you want to (see the environment section of L<Wasm::Wasmtime>.
 
 =head1 SEE ALSO
 

--- a/lib/Wasm/Wasmtime.pm
+++ b/lib/Wasm/Wasmtime.pm
@@ -41,6 +41,14 @@ If you are just getting your feet wet with WebAssembly and Perl then you probabl
 take a look at L<Wasm>, which is a simple interface that automatically imports functions
 from Wasm space into Perl space.
 
+=head1 ENVIRONMENT
+
+=head2 PERL_WASM_WASMTIME_MEMORY
+
+This environment variable, if set, should be a colon separated list of values for
+C<static_memory_maximum_size>, C<static_memory_guard_size> and C<dynamic_memory_guard_size>.
+See L<Wasm::Wasmtime::Config> for more details on these limits.
+
 =head1 SEE ALSO
 
 =over 4

--- a/lib/Wasm/Wasmtime/Config.pm
+++ b/lib/Wasm/Wasmtime/Config.pm
@@ -81,6 +81,8 @@ L<https://github.com/webassembly/bulk-memory>
 
 =head2 wasm_multi_value
 
+ $config->wasm_multi_value($bool)
+
 Configures whether the wasm multi value proposal is enabled.
 
 L<https://github.com/webassembly/multi-value>
@@ -97,6 +99,26 @@ foreach my $prop (qw( debug_info wasm_threads wasm_reference_types
     $self;
   });
 }
+
+=head2 static_memory_maximum_size
+
+ $config->static_memory_maximum_size($size);
+
+Configure the static memory maximum size.
+
+=head2 static_memory_guard_size
+
+ $config->static_memory_guard_size($size);
+
+Configure the static memory guard size.
+
+=head2 dynamic_memory_guard_size
+
+ $config->dynamic_memory_guard_size($size);
+
+Configure the dynamic memory guard size.
+
+=cut
 
 foreach my $prop (qw( static_memory_maximum_size static_memory_guard_size dynamic_memory_guard_size ))
 {

--- a/lib/Wasm/Wasmtime/Engine.pm
+++ b/lib/Wasm/Wasmtime/Engine.pm
@@ -41,6 +41,13 @@ Creates a new instance of the engine class.
 $ffi->attach( [ 'new_with_config' => 'new' ] => ['wasm_config_t'] => 'wasm_engine_t' => sub {
   my($xsub, $class, $config) = @_;
   $config ||= Wasm::Wasmtime::Config->new;
+  if(defined $ENV{PERL_WASM_WASMTIME_MEMORY})
+  {
+    my($static_memory_maximum_size, $static_memory_guard_size, $dynamic_memory_guard_size) = split /:/, $ENV{PERL_WASM_WASMTIME_MEMORY};
+    $config->static_memory_maximum_size($static_memory_maximum_size);
+    $config->static_memory_guard_size($static_memory_guard_size);
+    $config->dynamic_memory_guard_size($dynamic_memory_guard_size);
+  }
   my $self = $xsub->($config),
   delete $config->{ptr};
   $self;

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -14,6 +14,7 @@ $modules{$_} = $_ for qw(
   Devel::GlobalDestruction
   ExtUtils::MakeMaker
   FFI::C
+  FFI::C::StructDef
   FFI::CheckLib
   FFI::Platypus
   FFI::Platypus::Buffer
@@ -23,6 +24,7 @@ $modules{$_} = $_ for qw(
   Ref::Util
   Sub::Install
   Test2::API
+  Test2::Mock
   Test2::V0
   Test::Alien::Diag
 );

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -15,6 +15,7 @@ $modules{$_} = $_ for qw(
   ExtUtils::MakeMaker
   FFI::C
   FFI::C::StructDef
+  FFI::C::Util
   FFI::CheckLib
   FFI::Platypus
   FFI::Platypus::Buffer

--- a/t/test2_plugin_wasm.t
+++ b/t/test2_plugin_wasm.t
@@ -1,0 +1,6 @@
+use Test2::V0 -no_srand => 1;
+use Test2::Plugin::Wasm;
+
+ok 1;
+
+done_testing;

--- a/t/wasm.t
+++ b/t/wasm.t
@@ -1,4 +1,5 @@
 use Test2::V0 -no_srand => 1;
+use Test2::Plugin::Wasm;
 use Wasm;
 
 try_ok  { Wasm->import( -api => 0 );    }                                                   'works with -api => 0 ';

--- a/t/wasm_wasmtime.t
+++ b/t/wasm_wasmtime.t
@@ -1,4 +1,5 @@
 use Test2::V0 -no_srand => 1;
+use Test2::Plugin::Wasm;
 use Wasm::Wasmtime;
 use Path::Tiny qw( path );
 

--- a/t/wasm_wasmtime_extern.t
+++ b/t/wasm_wasmtime_extern.t
@@ -1,4 +1,5 @@
 use Test2::V0 -no_srand => 1;
+use Test2::Plugin::Wasm;
 use lib 't/lib';
 use Test2::Tools::Wasm;
 use Wasm::Wasmtime::Extern;

--- a/t/wasm_wasmtime_instance.t
+++ b/t/wasm_wasmtime_instance.t
@@ -1,4 +1,5 @@
 use Test2::V0 -no_srand => 1;
+use Test2::Plugin::Wasm;
 use lib 't/lib';
 use Test2::Tools::Wasm;
 use Wasm::Wasmtime::Module;

--- a/t/wasm_wasmtime_linker.t
+++ b/t/wasm_wasmtime_linker.t
@@ -1,4 +1,5 @@
 use Test2::V0 -no_srand => 1;
+use Test2::Plugin::Wasm;
 use lib 't/lib';
 use Test2::Tools::Wasm;
 use Wasm::Wasmtime::Linker;

--- a/t/wasm_wasmtime_memory.t
+++ b/t/wasm_wasmtime_memory.t
@@ -1,4 +1,5 @@
 use Test2::V0 -no_srand => 1;
+use Test2::Plugin::Wasm;
 use lib 't/lib';
 use Test2::Tools::Wasm;
 use Wasm::Wasmtime::Memory;


### PR DESCRIPTION
`t/wasm.t` still barfs for some reason.  We should also add some environment variables at some level for people to set limits for production.  This will help address #22.  This requires the dev version of wasmtime until the config properties is available in the next production version of wasmtime.