### PR TITLE
Add interface to Module Memory via Wasm.pm

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}},
 
 {{$NEXT}}
+  - Wasm::Wasmtime::Memory constructor can take a array reference in place
+    of the Wasm::Wasmtime::MemoryType (gh#48, gh#49)
+  - Added Wasm::Memory (gh#48, gh#49)
 
 0.08      2020-05-08 18:18:40 -0600
   - Added tie method to Wasm::Wasmtime::Global (gh#46)

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ exactly as you want to (see the environment section of
 
 # SEE ALSO
 
+- [Wasm::Memory](https://metacpan.org/pod/Wasm::Memory)
+
+    Interface to WebAssembly memory from Perl.
+
 - [Wasm::Wasmtime](https://metacpan.org/pod/Wasm::Wasmtime)
 
     Low level interface to `wasmtime`.

--- a/author.yml
+++ b/author.yml
@@ -36,4 +36,5 @@ pod_coverage:
     - Wasm::Wasmtime::Module::Exports#can
     - Wasm::Wasmtime::Module::Imports#new
     - Wasm::Wasmtime::Module::Imports#can
+    - Wasm::Memory#new
     - Test2::Plugin::Wasm

--- a/examples/synopsis/memory2.pl
+++ b/examples/synopsis/memory2.pl
@@ -1,0 +1,5 @@
+use strict;
+use warnings;
+use Wasm;
+
+# TODO

--- a/examples/synopsis/memory2.pl
+++ b/examples/synopsis/memory2.pl
@@ -1,5 +1,29 @@
 use strict;
 use warnings;
-use Wasm;
+use PeekPoke::FFI qw( peek poke );
+use Wasm
+  -api => 0,
+  -wat => q{
+    (module
+      (memory (export "memory") 3 9)
+    )
+  }
+;
 
-# TODO
+# $memory isa Wasm::Memory
+poke($memory->address + 10, 42);                # store the byte 42 at offset
+                                                # 10 inside the data region
+
+my($current, $min, $max) = $memory->limits;
+printf "size    = %x\n", $memory->size;         # 30000
+printf "current = %d\n", $current;              # 3
+printf "min     = %d\n", $min;                  # 3
+printf "max     = %d\n", $max;                  # 9
+
+$memory->grow(4);                               # increase data region by 4 pages
+
+($current, $min, $max) = $memory->limits;
+printf "size    = %x\n", $memory->size;         # 70000
+printf "current = %d\n", $current;              # 7
+printf "min     = %d\n", $min;                  # 3
+printf "max     = %d\n", $max;                  # 9

--- a/examples/wasm/memory.pl
+++ b/examples/wasm/memory.pl
@@ -1,0 +1,85 @@
+use strict;
+use warnings;
+use Carp::Assert;
+use Path::Tiny qw( path );
+use PeekPoke::FFI qw( peek poke );
+use Wasm
+  -api => 0,
+  -wat => q{
+    (module
+      (memory (export "memory") 2 3)
+
+      (func (export "size") (result i32) (memory.size))
+      (func (export "load") (param i32) (result i32)
+        (i32.load8_s (local.get 0))
+      )
+      (func (export "store") (param i32 i32)
+        (i32.store8 (local.get 0) (local.get 1))
+      )
+
+      (data (i32.const 0x1000) "\01\02\03\04")
+    )
+  }
+;
+
+print "Checking memory...\n";
+assert([$memory->limits]->[0] == 2);
+assert($memory->size == 0x20000);
+
+# Note that usage of `data` is unsafe! This is a raw C pointer which is not
+# bounds checked at all. We checked our `data_size` above but you'll want to be
+# very careful when accessing data through `data()`
+assert(peek($memory->address + 0x0000) == 0);
+assert(peek($memory->address + 0x1000) == 1);
+assert(peek($memory->address + 0x1003) == 4);
+
+assert(size() == 2);
+assert(load(0) == 0);
+assert(load(0x1000) == 1);
+assert(load(0x1003) == 4);
+assert(load(0x1ffff) == 0);
+
+# out of bounds trap
+{
+  local $@;
+  eval { load(0x20000) };
+  assert($@ =~ /wasm trap: out of bounds memory/);
+}
+
+print "Mutating memory...\n";
+poke($memory->address + 0x1003, 5);
+store(0x1002, 6);
+
+#out of bounds trap
+{
+  local $@;
+  eval { store(0x20000, 0) };
+  assert($@ =~ /wasm trap: out of bounds memory access/);
+}
+
+assert(peek($memory->address + 0x1002) == 6);
+assert(peek($memory->address + 0x1003) == 5);
+assert(load(0x1002) == 6);
+assert(peek($memory->address + 0x1003) == 5);
+
+# Grow memory
+assert($memory->grow(1));
+assert([$memory->limits]->[0] == 3);
+assert($memory->size == 0x30000);
+
+assert(load(0x20000) == 0);
+store(0x20000, 0);
+{
+  local $@;
+  eval { load(0x30000) };
+  assert($@ =~ /wasm trap: out of bounds memory/);
+}
+{
+  local $@;
+  eval { store(0x30000, 0) };
+  assert($@ =~ /wasm trap: out of bounds memory/);
+}
+
+# Memory can fail to grow
+assert(!$memory->grow(1));
+assert($memory->grow(0));

--- a/lib/Wasm.pm
+++ b/lib/Wasm.pm
@@ -144,6 +144,10 @@ L<Wasm::Wasmtime>.
 
 =over 4
 
+=item L<Wasm::Memory>
+
+Interface to WebAssembly memory from Perl.
+
 =item L<Wasm::Wasmtime>
 
 Low level interface to C<wasmtime>.

--- a/lib/Wasm.pm
+++ b/lib/Wasm.pm
@@ -389,6 +389,13 @@ sub import
       no strict 'refs';
       *{"${package}::$name"} = $global->tie;
     }
+    elsif($kind eq 'memory')
+    {
+      require Wasm::Memory;
+      my $memory = Wasm::Memory->new($extern);
+      no strict 'refs';
+      *{"${package}::$name"} = \$memory;
+    }
   }
 
   if($exporter)

--- a/lib/Wasm/Memory.pm
+++ b/lib/Wasm/Memory.pm
@@ -1,0 +1,76 @@
+package Wasm::Memory;
+
+use strict;
+use warnings;
+
+# ABSTRACT: Interface to Web Assembly Memory
+# VERSION
+
+=head1 SYNOPSIS
+
+# EXAMPLE: examples/synopsis/memory2.pl
+
+=head1 DESCRIPTION
+
+This class represents a region of memory exported from a WebAssembly
+module.
+
+=cut
+
+sub new
+{
+  my($class, $memory) = @_;
+  bless \$memory, $class;
+}
+
+=head1 METHODS
+
+=head2 address
+
+ my $pointer = $memory->address;
+
+Returns an opaque pointer to the start of memory.
+
+=head2 size
+
+ my $size = $memory->size;
+
+Returns the size of the memory in bytes.
+
+=cut
+
+sub address { ${shift()}->data      }
+sub size    { ${shift()}->data_size }
+
+=head2 limits
+
+ my($current, $min, $max) = $memory->limits;
+
+Returns the current memory limit, the minimum and maximum.  All sizes
+are in pages.
+
+=cut
+
+sub limits
+{
+  my $self   = shift;
+  my $memory = $$self;
+  my $type   = $memory->type;
+  ($memory->size, @{ $type->limits });
+}
+
+=head2 grow
+
+ $memory->grow($count);
+
+Grown the memory region by C<$count> pages.
+
+=cut
+
+sub grow
+{
+  my($self, $count) = @_;
+  ${$self}->grow($count);
+}
+
+1;

--- a/lib/Wasm/Wasmtime/Memory.pm
+++ b/lib/Wasm/Wasmtime/Memory.pm
@@ -3,7 +3,7 @@ package Wasm::Wasmtime::Memory;
 use strict;
 use warnings;
 use base qw( Wasm::Wasmtime::Extern );
-use Ref::Util qw( is_ref );
+use Ref::Util qw( is_ref is_plain_arrayref );
 use Wasm::Wasmtime::FFI;
 use Wasm::Wasmtime::Store;
 use Wasm::Wasmtime::MemoryType;
@@ -48,6 +48,8 @@ $ffi->attach( new => ['wasm_store_t', 'wasm_memorytype_t'] => 'wasm_memory_t' =>
   if(is_ref $_[0])
   {
     my($store, $memorytype) = @_;
+    $memorytype = Wasm::Wasmtime::MemoryType->new($memorytype)
+      if is_plain_arrayref $memorytype;
     return $xsub->($store, $memorytype);
   }
   else

--- a/t/wasm.t
+++ b/t/wasm.t
@@ -30,6 +30,14 @@ try_ok  { package Empty; Wasm->import( -api => 0, -wat => '(module)' ) }        
 
 is( Foo0::add(1,2), 3, '1+2=3' );
 is( Foo0::subtract(3,2), 1, '3-2=1' );
+is(
+  $Foo0::frooble,
+  object {
+    call [ isa => 'Wasm::Memory' ] => T();
+    call_list limits => [ 2, 2, 3 ];
+  },
+  'memory region exported',
+);
 
 {
   package Foo1;

--- a/t/wasm_memory.t
+++ b/t/wasm_memory.t
@@ -1,0 +1,26 @@
+use Test2::V0 -no_srand => 1;
+use Wasm::Wasmtime::Store;
+use Wasm::Wasmtime::Memory;
+use Wasm::Memory;
+
+my $store = Wasm::Wasmtime::Store->new;
+
+is(
+  Wasm::Memory->new(
+    Wasm::Wasmtime::Memory->new(
+      $store, [5,10],
+    )
+  ),
+  object {
+    call [ isa => 'Wasm::Memory' ] => T();
+    call address => match qr/^[0-9]+$/;
+    call size    => 327680;
+    call_list limits => [ 5, 5, 10 ];
+    call [ grow => 2 ] => T();
+    call_list limits => [ 7, 5, 10 ];
+  },
+  'create a memory object'
+);
+
+
+done_testing;

--- a/t/wasm_wasmtime_memory.t
+++ b/t/wasm_wasmtime_memory.t
@@ -46,4 +46,15 @@ is(
   'standalone',
 );
 
+is(
+  Wasm::Wasmtime::Memory->new(
+    Wasm::Wasmtime::Store->new,
+    [1,2],
+  ),
+  object {
+    call [ isa => 'Wasm::Wasmtime::Memory' ] => T();
+  },
+  'standalone (ii)',
+);
+
 done_testing;


### PR DESCRIPTION
#48 
 - [x] Wasm::Memory class
 - [x] Import Wasm::Memory objects into Perl space.
 - [x] add `examples/wasm/memory.pl` example port of the wasmtime example
 - [x] add synopsis in `examples/synopsis/memory2.pl`