### PR TITLE
make compat with dev first class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ jobs:
   include:
     - env: CIP_TAG=static
     - env: CIP_TAG=5.31
-    - env: CIP_TAG=5.30 ALIEN_WASMTIME_VERSION=dev
     - env: CIP_TAG=5.30-buster-arm64v8 ALIEN_WASMTIME_VERSION=dev
       arch: arm64
+    - env: CIP_TAG=5.30 ALIEN_WASMTIME_VERSION=dev
     - env: CIP_TAG=5.30
     - env: CIP_TAG=5.28
     - env: CIP_TAG=5.26

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ jobs:
     - env: CIP_TAG=5.10
     - env: CIP_TAG=5.8
   allow_failures:
-    - env: CIP_TAG=5.30 ALIEN_WASMTIME_VERSION=dev
-    - env: CIP_TAG=5.18 ALIEN_WASMTIME_VERSION=dev
     - env: CIP_TAG=5.30-buster-arm64v8 ALIEN_WASMTIME_VERSION=dev
       arch: arm64
 branches:


### PR DESCRIPTION
Let's make compatibility with wasmtime dev a first class priority.  dev has been pretty stable except one large breakage between 0.15 and 0.16.  I think it is better to fail on dev for now.  If we need to drop support for dev for a while we can adjust the travis.yml appropriately.