### PR TITLE
start working on 0.19.0 compat

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for {{$dist->name}}},
 
 {{$NEXT}}
+  [Warning: breaking changes]
+
+  - The Wasm::Wasmtime::Module constructor now takes an Engine as an
+    optional first argument, instead of a Store (gh#75, gh#76)
 
 0.14      2020-06-07 21:03:13 -0600
   - Require minimum Perl 5.8.4.  This was already the case in practice

--- a/t/lib/Test2/Tools/Wasm.pm
+++ b/t/lib/Test2/Tools/Wasm.pm
@@ -7,7 +7,7 @@ use Ref::Util qw( is_plain_arrayref );
 use Test2::API qw( context );
 use base qw( Exporter );
 
-our @EXPORT = qw( wasm_module_ok wasm_instance_ok wasm_func_ok );
+our @EXPORT = qw( wasm_store wasm_module_ok wasm_instance_ok wasm_func_ok );
 
 sub _module
 {
@@ -19,12 +19,7 @@ sub _module
   my $ctx = context();
 
   local $@ = '';
-  my $store = eval {
-    my $config = Wasm::Wasmtime::Config->new;
-    $config->wasm_multi_value(1);
-    my $engine = Wasm::Wasmtime::Engine->new($config);
-    Wasm::Wasmtime::Store->new($engine);
-  };
+  my $store = eval { wasm_store() };
   return $ctx->fail_and_release($name, "error creating store object", "$@") if $@;
 
   my $module = eval { Wasm::Wasmtime::Module->new($store, wat => $wat) };
@@ -121,6 +116,19 @@ sub wasm_func_ok ($$;$)
   $ctx->pass_and_release($name);
 
   return $extern;
+}
+
+my $store;
+
+sub wasm_store
+{
+  $store ||= do {
+    warn "new store";
+    my $config = Wasm::Wasmtime::Config->new;
+    $config->wasm_multi_value(1);
+    my $engine = Wasm::Wasmtime::Engine->new($config);
+    Wasm::Wasmtime::Store->new($engine);
+  };
 }
 
 1;

--- a/t/wasm_wasmtime_linker.t
+++ b/t/wasm_wasmtime_linker.t
@@ -21,7 +21,7 @@ my $instance = wasm_instance_ok( [], q{
 });
 
 my $module = $instance->module;
-my $store  = $module->store;
+my $store  = wasm_store();
 my $wasi   = Wasm::Wasmtime::WasiInstance->new(
   $store, "wasi_snapshot_preview1",
 );

--- a/t/wasm_wasmtime_module.t
+++ b/t/wasm_wasmtime_module.t
@@ -2,6 +2,7 @@ use 5.008004;
 use Test2::V0 -no_srand => 1;
 use lib 't/lib';
 use Test2::Tools::Wasm;
+use Wasm::Wasmtime::Engine;
 use Wasm::Wasmtime::Store;
 use Wasm::Wasmtime::Module;
 use Wasm::Wasmtime::Wat2Wasm;
@@ -10,12 +11,12 @@ is(
   Wasm::Wasmtime::Module->new(wat2wasm('(module)')),
   object {
     call ['isa', 'Wasm::Wasmtime::Module'] => T();
-    call store => object {
-      call ['isa', 'Wasm::Wasmtime::Store'] => T();
+    call engine => object {
+      call ['isa', 'Wasm::Wasmtime::Engine'] => T();
     };
     call to_string => "(module)\n";
   },
-  'autocreate store',
+  'autocreate engine',
 );
 
 is(
@@ -25,22 +26,22 @@ is(
 );
 
 is(
-  Wasm::Wasmtime::Module->new(Wasm::Wasmtime::Store->new, wat2wasm('(module)')),
+  Wasm::Wasmtime::Module->new(Wasm::Wasmtime::Engine->new, wat2wasm('(module)')),
   object {
     call ['isa', 'Wasm::Wasmtime::Module'] => T();
-    call store => object {
-      call ['isa', 'Wasm::Wasmtime::Store'] => T();
+    call engine => object {
+      call ['isa', 'Wasm::Wasmtime::Engine'] => T();
     };
   },
-  'explicit store',
+  'explicit engine',
 );
 
 is(
   Wasm::Wasmtime::Module->new(wat => '(module)'),
   object {
     call ['isa', 'Wasm::Wasmtime::Module'] => T();
-    call store => object {
-      call ['isa', 'Wasm::Wasmtime::Store'] => T();
+    call engine => object {
+      call ['isa', 'Wasm::Wasmtime::Engine'] => T();
     };
   },
   'wat key',
@@ -50,8 +51,8 @@ is(
   Wasm::Wasmtime::Module->new(wasm => wat2wasm('(module)')),
   object {
     call ['isa', 'Wasm::Wasmtime::Module'] => T();
-    call store => object {
-      call ['isa', 'Wasm::Wasmtime::Store'] => T();
+    call engine => object {
+      call ['isa', 'Wasm::Wasmtime::Engine'] => T();
     };
   },
   'wasm key',
@@ -61,8 +62,8 @@ is(
   Wasm::Wasmtime::Module->new(file => 'examples/wasmtime/gcd.wat'),
   object {
     call ['isa', 'Wasm::Wasmtime::Module'] => T();
-    call store => object {
-      call ['isa', 'Wasm::Wasmtime::Store'] => T();
+    call engine => object {
+      call ['isa', 'Wasm::Wasmtime::Engine'] => T();
     };
     call to_string => join("\n",
                         '(module',


### PR DESCRIPTION
This breaks back compat for the `Wasm::Wasmtime` api which is okay since we've been warning that might happen.  (It's also incomplete).

Another option would be to require a Store object when creating the module even though it isn't required by the underlying wasmtime module constructor.  We can get the Engine from the Store object.

requires:
https://github.com/perlwasm/Alien-wasmtime/pull/16

This is to handle this change:

```diff
 WASM_API_EXTERN own wasmtime_error_t *wasmtime_module_new(
-    wasm_store_t *store,
+    wasm_engine_t *engine,
     const wasm_byte_vec_t *binary,
     own wasm_module_t **ret
 );
```