### PR TITLE
compatability with wasmtime 0.19.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}},
 
 {{$NEXT}}
+  - Compatability with wasmtime 0.19.0 (gh#75, gh#77)
 
 0.14      2020-06-07 21:03:13 -0600
   - Require minimum Perl 5.8.4.  This was already the case in practice

--- a/lib/Wasm/Wasmtime/FFI.pm
+++ b/lib/Wasm/Wasmtime/FFI.pm
@@ -37,7 +37,7 @@ This is a private class used internally by L<Wasm::Wasmtime> classes.
 
 =cut
 
-our @EXPORT = qw( $ffi $ffi_prefix _generate_vec_class _generate_destroy );
+our @EXPORT = qw( $ffi $ffi_prefix _generate_vec_class _generate_destroy _ver_0_19_0 );
 
 sub _lib
 {
@@ -55,6 +55,15 @@ $ffi->mangler(sub {
   return $name if $name =~ /^(wasm|wasmtime|wasi)_/;
   return $ffi_prefix . $name;
 });
+
+sub _ver_0_19_0
+{
+  # ugly hack.  Since wasmtime doesn't have an interface for giving us its version
+  # we look for symbols that were in 0.19.0 but not in 0.18.0.  We can remove this
+  # when we later require 0.19.0.
+  # See also: https://github.com/perlwasm/Wasm/issues/75
+  !!$ffi->find_symbol('wasmtime_func_as_funcref');
+}
 
 { package Wasm::Wasmtime::Vec;
   use FFI::Platypus::Record;

--- a/lib/Wasm/Wasmtime/Module.pm
+++ b/lib/Wasm/Wasmtime/Module.pm
@@ -137,17 +137,34 @@ a useful diagnostic for why it was invalid.
 
 =cut
 
-$ffi->attach( [ wasmtime_module_new => 'new' ] => ['wasm_engine_t', 'wasm_byte_vec_t*', 'opaque*'] => 'wasmtime_error_t' => sub {
-  my $xsub = shift;
-  my $class = shift;
-  my($store, $wasm, $data) = _args(@_);
-  my $ptr;
-  if(my $error = $xsub->($store->engine, $$wasm, \$ptr))
-  {
-    Carp::croak("error creating module: " . $error->message);
-  }
-  bless { ptr => $ptr, store => $store }, $class;
-});
+if(_ver_0_19_0())
+{
+  $ffi->attach( [ wasmtime_module_new => 'new' ] => ['wasm_engine_t', 'wasm_byte_vec_t*', 'opaque*'] => 'wasmtime_error_t' => sub {
+    my $xsub = shift;
+    my $class = shift;
+    my($store, $wasm, $data) = _args(@_);
+    my $ptr;
+    if(my $error = $xsub->($store->engine, $$wasm, \$ptr))
+    {
+      Carp::croak("error creating module: " . $error->message);
+    }
+    bless { ptr => $ptr, store => $store }, $class;
+  });
+}
+else
+{
+  $ffi->attach( [ wasmtime_module_new => 'new' ] => ['wasm_store_t', 'wasm_byte_vec_t*', 'opaque*'] => 'wasmtime_error_t' => sub {
+    my $xsub = shift;
+    my $class = shift;
+    my($store, $wasm, $data) = _args(@_);
+    my $ptr;
+    if(my $error = $xsub->($store, $$wasm, \$ptr))
+    {
+      Carp::croak("error creating module: " . $error->message);
+    }
+    bless { ptr => $ptr, store => $store }, $class;
+  });
+}
 
 $ffi->attach( [ wasmtime_module_validate => 'validate' ] => ['wasm_store_t', 'wasm_byte_vec_t*'] => 'wasmtime_error_t' => sub {
   my $xsub = shift;

--- a/lib/Wasm/Wasmtime/Module.pm
+++ b/lib/Wasm/Wasmtime/Module.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use 5.008004;
 use Wasm::Wasmtime::FFI;
+use Wasm::Wasmtime::Engine;
 use Wasm::Wasmtime::Store;
 use Wasm::Wasmtime::Module::Exports;
 use Wasm::Wasmtime::Module::Imports;
@@ -136,12 +137,12 @@ a useful diagnostic for why it was invalid.
 
 =cut
 
-$ffi->attach( [ wasmtime_module_new => 'new' ] => ['wasm_store_t', 'wasm_byte_vec_t*', 'opaque*'] => 'wasmtime_error_t' => sub {
+$ffi->attach( [ wasmtime_module_new => 'new' ] => ['wasm_engine_t', 'wasm_byte_vec_t*', 'opaque*'] => 'wasmtime_error_t' => sub {
   my $xsub = shift;
   my $class = shift;
   my($store, $wasm, $data) = _args(@_);
   my $ptr;
-  if(my $error = $xsub->($store, $$wasm, \$ptr))
+  if(my $error = $xsub->($store->engine, $$wasm, \$ptr))
   {
     Carp::croak("error creating module: " . $error->message);
   }


### PR DESCRIPTION
This attempts to add comparability to 0.19.0 without breaking the Perl level API. (alternative to #76)