### PR TITLE
remove this old workaround for 0.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ jobs:
   include:
     - env: CIP_TAG=static
     - env: CIP_TAG=5.31
-    - env: CIP_TAG=5.30-buster-arm64v8 ALIEN_WASMTIME_VERSION=dev
+    - env: CIP_TAG=5.32-buster-arm64v8
       arch: arm64
-    - env: CIP_TAG=5.30 ALIEN_WASMTIME_VERSION=dev
+    - env: CIP_TAG=5.32 ALIEN_WASMTIME_VERSION=dev
     - env: CIP_TAG=5.30
     - env: CIP_TAG=5.28
     - env: CIP_TAG=5.26

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{$dist->name}}},
 
 {{$NEXT}}
   - Compatability with wasmtime 0.19.0 (gh#75, gh#77)
+  - Remove workaround for wasmtime 0.16.0 (gh#78)
 
 0.14      2020-06-07 21:03:13 -0600
   - Require minimum Perl 5.8.4.  This was already the case in practice

--- a/lib/Wasm/Wasmtime/Config.pm
+++ b/lib/Wasm/Wasmtime/Config.pm
@@ -154,23 +154,11 @@ Configure the dynamic memory guard size.
 outer:
 foreach my $prop (qw( static_memory_maximum_size static_memory_guard_size dynamic_memory_guard_size ))
 {
-  foreach my $suffix ('_set', '')
-  {
-    # not sure why, but this didn't make it into 0.16.0 :/
-    # https://github.com/bytecodealliance/wasmtime/pull/1662
-    my $f = eval { $ffi->function( "wasmtime_config_${prop}${suffix}" => [ 'wasm_config_t', 'uint64' ] => 'void' => sub {
-      my($xsub, $self, $value) = @_;
-      $xsub->($self, $value);
-      $self;
-    }) };
-    if($f)
-    {
-      $f->attach($prop);
-      next outer;
-    }
-  }
-
-  Carp::croak("unable to find either wasmtime_config_${prop} or wasmtime_config_${prop}_set");
+  $ffi->attach( [ "wasmtime_config_${prop}_set" => $prop ] => [ 'wasm_config_t', 'uint64' ] => 'void' => sub {
+    my($xsub, $self, $value) = @_;
+    $xsub->($self, $value);
+    $self;
+  });
 }
 
 =head2 strategy


### PR DESCRIPTION
This was fixed sometime between `0.16.0` and `0.18.0` and since we require `0.18.0` it is no longer necessary.