### PR TITLE
Deprecate Store object on Module class.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for {{$dist->name}}},
 
 {{$NEXT}}
   - Require Wasmtime 0.19.0 (via Alien::wasmtime 0.12 if necessary) (gh#73, gh#82)
+  - The store method on Wasm::Wasmtime::Module is deprecated and will be
+    removed from a future version of Wasm::Wasmtime (gh#73, gh#83)
 
 0.16      2020-07-18 06:07:45 -0600
   - Instance constructor may return a more useful error message on failure (gh#73, gh#79)

--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for {{$dist->name}}},
   - Require Wasmtime 0.19.0 (via Alien::wasmtime 0.12 if necessary) (gh#73, gh#82)
   - The store method on Wasm::Wasmtime::Module is deprecated and will be
     removed from a future version of Wasm::Wasmtime (gh#73, gh#83)
+  - Creating a Wasm::Wasmtime::Instance instance without a
+    Wasm::Wasmtime::Store object is now deprecated and will be removed
+    from a future version of Wasm::Wasmtime (gh#73, gh#83)
 
 0.16      2020-07-18 06:07:45 -0600
   - Instance constructor may return a more useful error message on failure (gh#73, gh#79)

--- a/examples/synopsis/caller.pl
+++ b/examples/synopsis/caller.pl
@@ -19,8 +19,9 @@ sub print_wasm_string
   print cstring($ptr + $memory->data);
 }
 
+my $store = Wasm::Wasmtime::Store->new;
 my $instance = Wasm::Wasmtime::Instance->new(
-  Wasm::Wasmtime::Module->new(wat => q{
+  Wasm::Wasmtime::Module->new($store, wat => q{
     (module
       (import "" "print_wasm_string" (func $print_wasm_string (param i32)))
       (func (export "run")
@@ -31,6 +32,7 @@ my $instance = Wasm::Wasmtime::Instance->new(
       (data (i32.const 0) "Hello, world!\n\00")
     )
   }),
+  $store,
   [\&print_wasm_string],
 );
 

--- a/examples/synopsis/extern.pl
+++ b/examples/synopsis/extern.pl
@@ -2,8 +2,9 @@ use strict;
 use warnings;
 use Wasm::Wasmtime;
 
+my $store = Wasm::Wasmtime::Store->new;
 my $instance = Wasm::Wasmtime::Instance->new(
-  Wasm::Wasmtime::Module->new(wat => q{
+  Wasm::Wasmtime::Module->new($store, wat => q{
     (module
       (func (export "foo") (param i32 i32) (result i32)
         local.get 0
@@ -12,6 +13,7 @@ my $instance = Wasm::Wasmtime::Instance->new(
       (memory (export "bar") 2 3)
     )
   }),
+  $store,
 );
 
 my $foo = $instance->exports->foo;

--- a/examples/synopsis/func1.pl
+++ b/examples/synopsis/func1.pl
@@ -4,7 +4,8 @@ use warnings;
 # Call a wasm function from Perl
 use Wasm::Wasmtime;
 
-my $module = Wasm::Wasmtime::Module->new( wat => q{
+my $store = Wasm::Wasmtime::Store->new;
+my $module = Wasm::Wasmtime::Module->new( $store, wat => q{
   (module
    (func (export "add") (param i32 i32) (result i32)
      local.get 0
@@ -13,6 +14,6 @@ my $module = Wasm::Wasmtime::Module->new( wat => q{
   )
 });
 
-my $instance = Wasm::Wasmtime::Instance->new($module);
+my $instance = Wasm::Wasmtime::Instance->new($module, $store);
 my $add = $instance->exports->add;
 print $add->call(1,2), "\n";  # 3

--- a/examples/synopsis/func2.pl
+++ b/examples/synopsis/func2.pl
@@ -18,6 +18,6 @@ my $hello = Wasm::Wasmtime::Func->new(
   sub { print "hello world!\n" },
 );
 
-my $instance = Wasm::Wasmtime::Instance->new($module, [$hello]);
+my $instance = Wasm::Wasmtime::Instance->new($module, $store, [$hello]);
 $instance->exports->run->call(); # hello world!
 

--- a/examples/synopsis/instance.pl
+++ b/examples/synopsis/instance.pl
@@ -2,5 +2,6 @@ use strict;
 use warnings;
 use Wasm::Wasmtime;
 
-my $module = Wasm::Wasmtime::Module->new(wat => '(module)');
-my $instance = Wasm::Wasmtime::Instance->new($module, []);
+my $store = Wasm::Wasmtime::Store->new;
+my $module = Wasm::Wasmtime::Module->new($store, wat => '(module)');
+my $instance = Wasm::Wasmtime::Instance->new($module, $store, []);

--- a/examples/synopsis/instance_exports.pl
+++ b/examples/synopsis/instance_exports.pl
@@ -2,7 +2,8 @@ use strict;
 use warnings;
 use Wasm::Wasmtime;
 
-my $module = Wasm::Wasmtime::Module->new( wat => q{
+my $store = Wasm::Wasmtime::Store->new;
+my $module = Wasm::Wasmtime::Module->new( $store, wat => q{
   (module
    (func (export "add") (param i32 i32) (result i32)
      local.get 0
@@ -11,7 +12,7 @@ my $module = Wasm::Wasmtime::Module->new( wat => q{
   )
 });
 
-my $instance = Wasm::Wasmtime::Instance->new($module);
+my $instance = Wasm::Wasmtime::Instance->new($module, $store);
 
 my $exports = $instance->exports;
 

--- a/examples/synopsis/table.pl
+++ b/examples/synopsis/table.pl
@@ -2,12 +2,14 @@ use strict;
 use warnings;
 use Wasm::Wasmtime;
 
+my $store = Wasm::Wasmtime::Store->new;
 my $instance = Wasm::Wasmtime::Instance->new(
-  Wasm::Wasmtime::Module->new(wat => q{
+  Wasm::Wasmtime::Module->new($store, wat => q{
     (module
       (table (export "table") 1 funcref)
     )
   }),
+  $store,
 );
 
 my $table = $instance->exports->table;

--- a/examples/synopsis/wasmtime.pl
+++ b/examples/synopsis/wasmtime.pl
@@ -53,7 +53,7 @@ sub hello
   print "hello world!\n";
 }
 
-my $instance = Wasm::Wasmtime::Instance->new( $module, [\&hello] );
+my $instance = Wasm::Wasmtime::Instance->new( $module, $store, [\&hello] );
 
 # call a WebAssembly function that calls back into Perl space
 $instance->exports->call_hello;

--- a/examples/wasmtime/gcd.pl
+++ b/examples/wasmtime/gcd.pl
@@ -3,8 +3,9 @@ use warnings;
 use Path::Tiny qw( path );
 use Wasm::Wasmtime;
 
-my $module = Wasm::Wasmtime::Module->new( file => path(__FILE__)->parent->child('gcd.wat') );
-my $instance = Wasm::Wasmtime::Instance->new($module);
+my $store = Wasm::Wasmtime::Store->new;
+my $module = Wasm::Wasmtime::Module->new( $store, file => path(__FILE__)->parent->child('gcd.wat') );
+my $instance = Wasm::Wasmtime::Instance->new($module, $store);
 my $gcd = $instance->exports->gcd;
 
 print "gcd(6,27) = @{[ $gcd->(6,27) ]}\n";

--- a/examples/wasmtime/hello.pl
+++ b/examples/wasmtime/hello.pl
@@ -18,5 +18,5 @@ sub say_hello
 }
 
 ## And with all that we can instantiate our module and call the export!
-my $instance = Wasm::Wasmtime::Instance->new($module, [\&say_hello]);
+my $instance = Wasm::Wasmtime::Instance->new($module, $store, [\&say_hello]);
 $instance->exports->run->();

--- a/examples/wasmtime/memory.pl
+++ b/examples/wasmtime/memory.pl
@@ -5,9 +5,9 @@ use Path::Tiny qw( path );
 use Wasm::Wasmtime;
 use PeekPoke::FFI qw( peek poke );
 
-
-my $module = Wasm::Wasmtime::Module->new( file => path(__FILE__)->parent->child('memory.wat') );
-my $instance = Wasm::Wasmtime::Instance->new($module);
+my $wasm_store = Wasm::Wasmtime::Store->new;
+my $module = Wasm::Wasmtime::Module->new( $wasm_store, file => path(__FILE__)->parent->child('memory.wat') );
+my $instance = Wasm::Wasmtime::Instance->new($module, $wasm_store);
 
 my $memory = $instance->exports->memory;
 my $size   = $instance->exports->size;

--- a/examples/wasmtime/multi.pl
+++ b/examples/wasmtime/multi.pl
@@ -29,7 +29,7 @@ sub callback_func
 
 print "Instantiating module...\n";
 my $instance = Wasm::Wasmtime::Instance->new(
-  $module, [\&callback_func],
+  $module, $store, [\&callback_func],
 );
 
 print "Extracting export...\n";

--- a/lib/Wasm/Wasmtime/Instance.pm
+++ b/lib/Wasm/Wasmtime/Instance.pm
@@ -36,6 +36,15 @@ $ffi->load_custom_type('::PtrObject' => 'wasm_instance_t' => __PACKAGE__);
 =head2 new
 
  my $instance = Wasm::Wasmtime::Instance->new(
+   $module,    # Wasm::Wasmtime::Module
+   $store      # Wasm::Wasmtime::Store
+ );
+ my $instance = Wasm::Wasmtime::Instance->new(
+   $module,    # Wasm::Wasmtime::Module
+   $store,     # Wasm::Wasmtime::Store
+   \@imports,  # array reference of Wasm::Wasmtime::Extern
+ );
+ my $instance = Wasm::Wasmtime::Instance->new(
    $module     # Wasm::Wasmtime::Module
  );
  my $instance = Wasm::Wasmtime::Instance->new(
@@ -112,6 +121,12 @@ $ffi->attach( [ wasmtime_instance_new => 'new' ] => ['wasm_store_t','wasm_module
   my $xsub = shift;
   my $class = shift;
   my $module = shift;
+  my $store = is_blessed_ref($_[0]) && $_[0]->isa('Wasm::Wasmtime::Store')
+    ? shift
+    : do {
+      no warnings 'deprecated';
+      $module->store;
+    };
 
   my $ptr;
   my @keep;
@@ -133,7 +148,6 @@ $ffi->attach( [ wasmtime_instance_new => 'new' ] => ['wasm_store_t','wasm_module
     Carp::confess("imports is not an array reference") unless ref($imports) eq 'ARRAY';
     my @imports = @$imports;
     my $trap;
-    my $store = $module->store;
 
     {
       my @mi = @{ $module->imports };

--- a/lib/Wasm/Wasmtime/Instance.pm
+++ b/lib/Wasm/Wasmtime/Instance.pm
@@ -44,9 +44,12 @@ $ffi->load_custom_type('::PtrObject' => 'wasm_instance_t' => __PACKAGE__);
    $store,     # Wasm::Wasmtime::Store
    \@imports,  # array reference of Wasm::Wasmtime::Extern
  );
+ 
+ # deprecated usage: without $store
  my $instance = Wasm::Wasmtime::Instance->new(
    $module     # Wasm::Wasmtime::Module
  );
+ # deprecated usage: without $store
  my $instance = Wasm::Wasmtime::Instance->new(
    $module,    # Wasm::Wasmtime::Module
    \@imports,  # array reference of Wasm::Wasmtime::Extern
@@ -74,6 +77,12 @@ For a memory import, a memory object will be created.  You won't be able to
 access it from Perl space, but at least it won't die.
 
 =back
+
+[B<Deprecated>: Will be removed in a future version of L<Wasm::Wasmtime>]
+
+You can create an L<Wasm::Wasmtime::Instance> instance without a
+L<Wasm::Wasmtime::Store> object, but this usage is deprecated, and will
+be removed from a future version of L<Wasm::Wasmtime>.
 
 =cut
 
@@ -124,6 +133,10 @@ $ffi->attach( [ wasmtime_instance_new => 'new' ] => ['wasm_store_t','wasm_module
   my $store = is_blessed_ref($_[0]) && $_[0]->isa('Wasm::Wasmtime::Store')
     ? shift
     : do {
+      if(warnings::enabled("deprecated"))
+      {
+        Carp::carp('Creating a Wasm::Wasmtime::Instance instance without a Wasm::Wasmtime::Store object is deprecated and will be removed in a future version of Wasm::Wasmtime');
+      }
       no warnings 'deprecated';
       $module->store;
     };

--- a/lib/Wasm/Wasmtime/Linker.pm
+++ b/lib/Wasm/Wasmtime/Linker.pm
@@ -164,7 +164,7 @@ $ffi->attach( instantiate => ['wasmtime_linker_t','wasm_module_t','opaque*','opa
   elsif($ptr)
   {
     return Wasm::Wasmtime::Instance->new(
-      $module, $ptr,
+      $module, $self->store, $ptr,
     );
   }
   else

--- a/lib/Wasm/Wasmtime/Module.pm
+++ b/lib/Wasm/Wasmtime/Module.pm
@@ -199,15 +199,35 @@ $ffi->attach( [ imports => '_imports' ] => [ 'wasm_module_t', 'wasm_importtype_v
   $imports->to_list;
 });
 
+=head2 engine
+
+ my $engine = $module->engine;
+
+Returns the L<Wasm::Wasmtime::Engine> object used by this module.
+
+=cut
+
+sub engine { shift->{store}->engine }
+
 =head2 store
 
  my $store = $module->store;
+
+[B<Deprecated>: Will be removed in a future version of L<Wasm::Wasmtime>]
 
 Returns the L<Wasm::Wasmtime::Store> object used by this module.
 
 =cut
 
-sub store { shift->{store} }
+sub store
+{
+  my($self) = @_;
+  if(warnings::enabled("deprecated"))
+  {
+    Carp::carp('The store method for the Wasm::Wasmtime::Module class is deprecated and will be removed in a future version of Wasm::Wasmtime');
+  }
+  $self->{store};
+}
 
 =head2 to_string
 

--- a/t/lib/Test2/Tools/Wasm.pm
+++ b/t/lib/Test2/Tools/Wasm.pm
@@ -7,7 +7,7 @@ use Ref::Util qw( is_plain_arrayref );
 use Test2::API qw( context );
 use base qw( Exporter );
 
-our @EXPORT = qw( wasm_module_ok wasm_instance_ok wasm_func_ok );
+our @EXPORT = qw( wasm_store wasm_module_ok wasm_instance_ok wasm_func_ok );
 
 sub _module
 {
@@ -19,12 +19,7 @@ sub _module
   my $ctx = context();
 
   local $@ = '';
-  my $store = eval {
-    my $config = Wasm::Wasmtime::Config->new;
-    $config->wasm_multi_value(1);
-    my $engine = Wasm::Wasmtime::Engine->new($config);
-    Wasm::Wasmtime::Store->new($engine);
-  };
+  my $store = eval { wasm_store() };
   return $ctx->fail_and_release($name, "error creating store object", "$@") if $@;
 
   my $module = eval { Wasm::Wasmtime::Module->new($store, wat => $wat) };
@@ -121,6 +116,18 @@ sub wasm_func_ok ($$;$)
   $ctx->pass_and_release($name);
 
   return $extern;
+}
+
+my $store;
+
+sub wasm_store
+{
+  $store ||= do {
+    my $config = Wasm::Wasmtime::Config->new;
+    $config->wasm_multi_value(1);
+    my $engine = Wasm::Wasmtime::Engine->new($config);
+    Wasm::Wasmtime::Store->new($engine);
+  };
 }
 
 1;

--- a/t/lib/Test2/Tools/Wasm.pm
+++ b/t/lib/Test2/Tools/Wasm.pm
@@ -41,7 +41,7 @@ sub _instance
 
   my $ctx = context();
 
-  my $instance = eval { Wasm::Wasmtime::Instance->new($module, $imports) };
+  my $instance = eval { Wasm::Wasmtime::Instance->new($module, wasm_store(), $imports) };
   return $ctx->fail_and_release($name, "error creating instance", "$@") if $@;
 
   $ctx->release;

--- a/t/wasm_wasmtime_caller.t
+++ b/t/wasm_wasmtime_caller.t
@@ -29,7 +29,7 @@ is(wasmtime_caller(), U());
     },
   );
 
-  my $instance = Wasm::Wasmtime::Instance->new($module, [$hello]);
+  my $instance = Wasm::Wasmtime::Instance->new($module, $store, [$hello]);
   $instance->exports->run->call(); # hello world!
 
   isa_ok $caller, 'Wasm::Wasmtime::Caller';

--- a/t/wasm_wasmtime_instance_exports.t
+++ b/t/wasm_wasmtime_instance_exports.t
@@ -1,11 +1,13 @@
 use 5.008004;
 use Test2::V0 -no_srand => 1;
+use Wasm::Wasmtime::Store;
 use Wasm::Wasmtime::Instance;
 use Wasm::Wasmtime::Instance::Exports;
 use YAML qw( Dump );
 
 {
-  my $module = Wasm::Wasmtime::Module->new(wat => q{
+  my $store = Wasm::Wasmtime::Store->new;
+  my $module = Wasm::Wasmtime::Module->new($store, wat => q{
     (module
       (func (export "add") (param i32 i32) (result i32)
         local.get 0
@@ -13,7 +15,7 @@ use YAML qw( Dump );
         i32.add)
     )
   });
-  my $instance = Wasm::Wasmtime::Instance->new($module, []);
+  my $instance = Wasm::Wasmtime::Instance->new($module, $store, []);
   my $exports = Wasm::Wasmtime::Instance::Exports->new($instance);
   is(
     $exports,

--- a/t/wasm_wasmtime_linker.t
+++ b/t/wasm_wasmtime_linker.t
@@ -28,6 +28,7 @@ my $wasi   = Wasm::Wasmtime::WasiInstance->new(
 
 my $instance2 = Wasm::Wasmtime::Instance->new(
   Wasm::Wasmtime::Module->new($store, wat => '(module)' ),
+  $store,
 );
 
 my $module2 = Wasm::Wasmtime::Module->new($store, wat => '(module)' );

--- a/t/wasm_wasmtime_linker.t
+++ b/t/wasm_wasmtime_linker.t
@@ -21,7 +21,7 @@ my $instance = wasm_instance_ok( [], q{
 });
 
 my $module = $instance->module;
-my $store  = $module->store;
+my $store  = wasm_store();
 my $wasi   = Wasm::Wasmtime::WasiInstance->new(
   $store, "wasi_snapshot_preview1",
 );

--- a/xt/author/cycle.t
+++ b/xt/author/cycle.t
@@ -30,8 +30,10 @@ subtest 'module' => sub {
 
 subtest 'instance' => sub {
 
+  my $store = Wasm::Wasmtime::Store->new;
   my $instance = Wasm::Wasmtime::Instance->new(
     Wasm::Wasmtime::Module->new(
+      $store,
       wat => q{
         (module
           (func (export "add") (param i32 i32) (result i32)
@@ -41,6 +43,7 @@ subtest 'instance' => sub {
         )
       },
     ),
+    $store,
     [],
   );
 

--- a/xt/author/examples.t
+++ b/xt/author/examples.t
@@ -13,6 +13,7 @@ foreach my $example (map { bsd_glob "examples/$_/*.pl" } qw( synopsis wasmtime w
   script_runs $example, { stdout => \$out, stderr => \$err };
   note "[out]\n$out" if $out ne '';
   note "[err]\n$err" if $err ne '';
+  unlike $err, qr/deprecated/, "no deprecation warnings ($example)";
 }
 
 done_testing;


### PR DESCRIPTION
This deprecates the Store object on the Module, and creating an Instance object without a Store, which relies on the Module's Store object.

The next step will be to remove these deprecated features and allowing Module to be created with just an Engine instead of a store.  We may want to deprecate creating an Instance with a Store at that point as well.

We also check for deprecation warnings on tests, which was useful in this PR and may be useful in the future if other constructs are deprecated.

The deprecation warnings can be turned off with `no warnings 'deprecated';`